### PR TITLE
Add blank line after copyright headers

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,7 @@
+// Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of LogiScanner application
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,3 +1,7 @@
+# Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+# All rights reserved.
+# This file is a part of LogiScanner application
+
 # Add project specific ProGuard rules here.
 # You can control the set of applied configuration files using the
 # proguardFiles setting in build.gradle.

--- a/app/src/androidTest/java/consulting/sw/logiscanner/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/consulting/sw/logiscanner/ExampleInstrumentedTest.kt
@@ -1,3 +1,7 @@
+// Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of LogiScanner application
+
 package consulting.sw.logiscanner
 
 import androidx.test.platform.app.InstrumentationRegistry

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+All rights reserved.
+This file is a part of LogiScanner application
+-->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 

--- a/app/src/main/java/consulting/sw/logiscanner/MainActivity.kt
+++ b/app/src/main/java/consulting/sw/logiscanner/MainActivity.kt
@@ -1,3 +1,7 @@
+// Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of LogiScanner application
+
 package consulting.sw.logiscanner
 
 import android.content.Context

--- a/app/src/main/java/consulting/sw/logiscanner/net/ApiModels.kt
+++ b/app/src/main/java/consulting/sw/logiscanner/net/ApiModels.kt
@@ -1,3 +1,7 @@
+// Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of LogiScanner application
+
 package consulting.sw.logiscanner.net
 
 import com.squareup.moshi.JsonClass

--- a/app/src/main/java/consulting/sw/logiscanner/net/ApiService.kt
+++ b/app/src/main/java/consulting/sw/logiscanner/net/ApiService.kt
@@ -1,3 +1,7 @@
+// Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of LogiScanner application
+
 package consulting.sw.logiscanner.net
 
 import retrofit2.http.Body

--- a/app/src/main/java/consulting/sw/logiscanner/net/NetworkModule.kt
+++ b/app/src/main/java/consulting/sw/logiscanner/net/NetworkModule.kt
@@ -1,3 +1,7 @@
+// Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of LogiScanner application
+
 package consulting.sw.logiscanner.net
 
 import com.squareup.moshi.Moshi

--- a/app/src/main/java/consulting/sw/logiscanner/repo/AppRepository.kt
+++ b/app/src/main/java/consulting/sw/logiscanner/repo/AppRepository.kt
@@ -1,3 +1,7 @@
+// Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of LogiScanner application
+
 package consulting.sw.logiscanner.repo
 
 import consulting.sw.logiscanner.net.ApiService

--- a/app/src/main/java/consulting/sw/logiscanner/repo/LoginRepository.kt
+++ b/app/src/main/java/consulting/sw/logiscanner/repo/LoginRepository.kt
@@ -1,3 +1,7 @@
+// Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of LogiScanner application
+
 package consulting.sw.logiscanner.repo
 
 import android.content.Context

--- a/app/src/main/java/consulting/sw/logiscanner/repo/ScanRepository.kt
+++ b/app/src/main/java/consulting/sw/logiscanner/repo/ScanRepository.kt
@@ -1,3 +1,7 @@
+// Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of LogiScanner application
+
 package consulting.sw.logiscanner.repo
 
 import consulting.sw.logiscanner.net.NetworkModule

--- a/app/src/main/java/consulting/sw/logiscanner/scan/Mt93ScanReceiver.kt
+++ b/app/src/main/java/consulting/sw/logiscanner/scan/Mt93ScanReceiver.kt
@@ -1,3 +1,7 @@
+// Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of LogiScanner application
+
 package consulting.sw.logiscanner.scan
 
 import android.content.BroadcastReceiver

--- a/app/src/main/java/consulting/sw/logiscanner/store/AuthStore.kt
+++ b/app/src/main/java/consulting/sw/logiscanner/store/AuthStore.kt
@@ -1,3 +1,7 @@
+// Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of LogiScanner application
+
 package consulting.sw.logiscanner.store
 
 import android.content.Context

--- a/app/src/main/java/consulting/sw/logiscanner/ui/MainViewModel.kt
+++ b/app/src/main/java/consulting/sw/logiscanner/ui/MainViewModel.kt
@@ -1,3 +1,7 @@
+// Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of LogiScanner application
+
 package consulting.sw.logiscanner.ui
 
 import android.app.Application

--- a/app/src/main/java/consulting/sw/logiscanner/ui/theme/Color.kt
+++ b/app/src/main/java/consulting/sw/logiscanner/ui/theme/Color.kt
@@ -1,3 +1,7 @@
+// Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of LogiScanner application
+
 package consulting.sw.logiscanner.ui.theme
 
 import androidx.compose.ui.graphics.Color

--- a/app/src/main/java/consulting/sw/logiscanner/ui/theme/Theme.kt
+++ b/app/src/main/java/consulting/sw/logiscanner/ui/theme/Theme.kt
@@ -1,3 +1,7 @@
+// Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of LogiScanner application
+
 package consulting.sw.logiscanner.ui.theme
 
 import android.app.Activity

--- a/app/src/main/java/consulting/sw/logiscanner/ui/theme/Type.kt
+++ b/app/src/main/java/consulting/sw/logiscanner/ui/theme/Type.kt
@@ -1,3 +1,7 @@
+// Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of LogiScanner application
+
 package consulting.sw.logiscanner.ui.theme
 
 import androidx.compose.material3.Typography

--- a/app/src/main/res/drawable/ic_launcher_background.xml
+++ b/app/src/main/res/drawable/ic_launcher_background.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+All rights reserved.
+This file is a part of LogiScanner application
+-->
+
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="108dp"
     android:height="108dp"

--- a/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+All rights reserved.
+This file is a part of LogiScanner application
+-->
+
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:aapt="http://schemas.android.com/aapt"
     android:width="108dp"

--- a/app/src/main/res/mipmap-anydpi/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi/ic_launcher.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+All rights reserved.
+This file is a part of LogiScanner application
+-->
+
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />

--- a/app/src/main/res/mipmap-anydpi/ic_launcher_round.xml
+++ b/app/src/main/res/mipmap-anydpi/ic_launcher_round.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+All rights reserved.
+This file is a part of LogiScanner application
+-->
+
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@drawable/ic_launcher_background" />
     <foreground android:drawable="@drawable/ic_launcher_foreground" />

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+All rights reserved.
+This file is a part of LogiScanner application
+-->
+
 <resources>
     <color name="purple_200">#FFBB86FC</color>
     <color name="purple_500">#FF6200EE</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+All rights reserved.
+This file is a part of LogiScanner application
+-->
+
 <resources>
     <string name="app_name">LogiScanner</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+All rights reserved.
+This file is a part of LogiScanner application
+-->
+
 <resources>
 
     <style name="Theme.LogiScanner" parent="android:Theme.Material.Light.NoActionBar" />

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,4 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+All rights reserved.
+This file is a part of LogiScanner application
+-->
+
+<!--
    Sample backup rules file; uncomment and customize as necessary.
    See https://developer.android.com/guide/topics/data/autobackup
    for details.

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,4 +1,11 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+All rights reserved.
+This file is a part of LogiScanner application
+-->
+
+<!--
    Sample data extraction rules file; uncomment and customize as necessary.
    See https://developer.android.com/about/versions/12/backup-restore#xml-changes
    for details.

--- a/app/src/test/java/consulting/sw/logiscanner/ExampleUnitTest.kt
+++ b/app/src/test/java/consulting/sw/logiscanner/ExampleUnitTest.kt
@@ -1,3 +1,7 @@
+// Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of LogiScanner application
+
 package consulting.sw.logiscanner
 
 import org.junit.Test

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,7 @@
+// Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of LogiScanner application
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,7 @@
+# Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+# All rights reserved.
+# This file is a part of LogiScanner application
+
 # Project-wide Gradle settings.
 # IDE (e.g. Android Studio) users:
 # Gradle settings configured through the IDE *will override*

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,3 +1,7 @@
+# Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+# All rights reserved.
+# This file is a part of LogiScanner application
+
 #Wed Jan 21 10:45:27 MSK 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,7 @@
+// Copyright (C) 2026 Maxim [maxirmx] Samsonov (www.sw.consulting)
+// All rights reserved.
+// This file is a part of LogiScanner application
+
 pluginManagement {
     repositories {
         google {


### PR DESCRIPTION
### Motivation
- Ensure a consistent blank line separates the three-line copyright header from file content across sources, config files and XML resources.
- Address inline comments requesting an empty line after the inserted copyright header.

### Description
- Inserted a single blank line after the three-line copyright header in Kotlin sources (`.kt`), Kotlin scripts (`.kts`), Gradle/proguard/properties config files and XML resources.
- Preserved the XML prolog (`<?xml ...?>`) as the first line when present and added the header plus the requested blank line immediately after it.
- Applied the spacing fix across project files (31 files updated, including `app` sources, resource XMLs, `build.gradle.kts`, `settings.gradle.kts`, `gradle.properties` and `gradle/wrapper/gradle-wrapper.properties`).
- No code logic changes were made beyond spacing and header placement.

### Testing
- Ran `./gradlew test lint`, which failed to run because the Android SDK location was not configured and requires `ANDROID_HOME` or a `local.properties` file with `sdk.dir`.
- Because the SDK was missing, unit tests and lint did not complete and therefore produced no pass/fail results.
- Executed a header-normalization script to add the requested blank lines and inspected sample files to verify headers and spacing were added as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69709a919d2c83218d8e8ad8a627d031)